### PR TITLE
Fix Google Maps request protocol

### DIFF
--- a/js/google_map.js
+++ b/js/google_map.js
@@ -33,7 +33,7 @@ function init() {
     var addresses = ['Brooklyn'];
 
     for (var x = 0; x < addresses.length; x++) {
-        $.getJSON('http://maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
+        $.getJSON('https://maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
             var p = data.results[0].geometry.location
             var latlng = new google.maps.LatLng(p.lat, p.lng);
             new google.maps.Marker({


### PR DESCRIPTION
## Summary
- patch Google Maps script to use HTTPS for API request

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6840eb5753308322ba1997428bd578b1